### PR TITLE
Scope fields to the current object in order to populate belongs_to

### DIFF
--- a/app/views/fields/nested_has_many/_fields.html.erb
+++ b/app/views/fields/nested_has_many/_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="nested-fields" style="width:100%">
+  <% field.nested_fields_for_attr(f.object).each do |attribute| -%>
 
-  <% field.nested_fields.each do |attribute| -%>
     <div class="field-unit field-unit--<%= attribute.html_class %>">
       <%= render_field attribute, f: f %>
     </div>

--- a/lib/administrate/field/nested_has_many.rb
+++ b/lib/administrate/field/nested_has_many.rb
@@ -20,6 +20,12 @@ module Administrate
         end
       end
 
+      def nested_fields_for_obj(obj)
+        associated_form(obj).attributes.reject do |nested_field|
+          skipped_fields.include?(nested_field.attribute)
+        end
+      end
+
       def to_s
         data
       end
@@ -48,8 +54,8 @@ module Administrate
         associated_class_name.underscore.pluralize
       end
 
-      def associated_form
-        Administrate::Page::Form.new(associated_dashboard, association_name)
+      def associated_form(resource=association_name)
+        Administrate::Page::Form.new(associated_dashboard, resource)
       end
 
       private


### PR DESCRIPTION
Fields were being fetched against the class, without the data attribute. Other attributes seem to pull in properly, but belongs_to don't. 